### PR TITLE
Update artifact publication co-ordinates

### DIFF
--- a/vfs-azure/pom.xml
+++ b/vfs-azure/pom.xml
@@ -57,7 +57,7 @@
             <distributionManagement>
                 <repository>
                     <id>bintray</id>
-                    <url>https://api.bintray.com/maven/dalet-oss/maven/vfs-azure/;publish=1</url>
+                    <url>https://api.bintray.com/maven/dalet-oss/maven/com.dalet%3Avfs-azure/;publish=1</url>
                 </repository>
             </distributionManagement>
 


### PR DESCRIPTION
Since we're now using `com.dalet` as the groupId instead of `com.dalet.sludev.commons`, I've also updated the package name on Bintray to make clear the difference (old artifacts remain published under the old package).