### PR TITLE
Updated azure blob storage lib version to latest for fix of non ascii character issue

### DIFF
--- a/vfs-azure/pom.xml
+++ b/vfs-azure/pom.xml
@@ -153,7 +153,7 @@
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-storage-blob</artifactId>
-            <version>12.8.0</version>
+            <version>12.10.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
When there is a comma in file name or path was ignored/not discovered by vfs azure