### PR TITLE
FLEX-64152 : Increased Azure blocksize to 8MB

### DIFF
--- a/vfs-azure/src/main/java/com/dalet/vfs2/provider/azure/AzFileObject.java
+++ b/vfs-azure/src/main/java/com/dalet/vfs2/provider/azure/AzFileObject.java
@@ -65,10 +65,11 @@ public class AzFileObject extends AbstractFileObject<AzFileSystem> {
 
     protected static final long MEGABYTES_TO_BYTES_MULTIPLIER = (int) Math.pow(2.0, 20.0);
 
-    protected static final int DEFAULT_UPLOAD_BLOCK_SIZE_MB = 4;
+    // Increased default size : Fix for FLEX-64152
+    protected static final int DEFAULT_UPLOAD_BLOCK_SIZE_MB = 8;
     private static final int TWENTY_FOUR_HOURS_IN_SEC = 24 * 60 * 60;
 
-    private static final long STREAM_BUFFER_SIZE_MB = 4 * MEGABYTES_TO_BYTES_MULTIPLIER;
+    private static final long STREAM_BUFFER_SIZE_MB = DEFAULT_UPLOAD_BLOCK_SIZE_MB * MEGABYTES_TO_BYTES_MULTIPLIER;
     private static final long BLOB_COPY_THRESHOLD_MB = 256 * MEGABYTES_TO_BYTES_MULTIPLIER;
 
     private static final int AZURE_MAX_BLOCKS = 50000;

--- a/vfs-azure/src/test/java/com/dalet/vfs2/provider/azure/AzFileProviderTest.java
+++ b/vfs-azure/src/test/java/com/dalet/vfs2/provider/azure/AzFileProviderTest.java
@@ -554,7 +554,8 @@ public class AzFileProviderTest {
 
             // 250 GB
             blockSize = fileObject.getBlockSize((250L * 1024L) * AzFileObject.MEGABYTES_TO_BYTES_MULTIPLIER);
-            assertEquals(5368709, blockSize);
+            assertEquals(AzFileObject.DEFAULT_UPLOAD_BLOCK_SIZE_MB * AzFileObject.MEGABYTES_TO_BYTES_MULTIPLIER, blockSize);
+
         }
         catch (FileSystemException e) {
             fail();


### PR DESCRIPTION
- Increased the Default block size of azure to 8MB to avoid large file upload failure
- To fix ticket [FLEX-64152]( https://dalet.atlassian.net/browse/FLEX-64152) 