### PR TITLE
Return last modified date in milliseconds

### DIFF
--- a/vfs-azure/pom.xml
+++ b/vfs-azure/pom.xml
@@ -50,9 +50,9 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.javadoc.failOnError>false</maven.javadoc.failOnError>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
     <revision>DEV</revision>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
 
   <!-- To check for plugin updates, uncomment the below and run `mvn org.codehaus.mojo:versions-maven-plugin:2.8.1:display-plugin-updates` -->

--- a/vfs-azure/pom.xml
+++ b/vfs-azure/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <name>vfs-azure</name>
@@ -48,9 +49,6 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
-
     <maven.javadoc.failOnError>false</maven.javadoc.failOnError>
     <revision>DEV</revision>
   </properties>
@@ -216,12 +214,28 @@
       <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
       <version>2.22.1</version>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>5.12.0</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+      <version>6.1.11</version>
+      <scope>test</scope>
+    </dependency>
+
 
   </dependencies>
 

--- a/vfs-azure/pom.xml
+++ b/vfs-azure/pom.xml
@@ -51,6 +51,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.javadoc.failOnError>false</maven.javadoc.failOnError>
     <revision>DEV</revision>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
 
   <!-- To check for plugin updates, uncomment the below and run `mvn org.codehaus.mojo:versions-maven-plugin:2.8.1:display-plugin-updates` -->
@@ -228,14 +230,6 @@
       <version>5.12.0</version>
       <scope>test</scope>
     </dependency>
-
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-core</artifactId>
-      <version>6.1.11</version>
-      <scope>test</scope>
-    </dependency>
-
 
   </dependencies>
 

--- a/vfs-azure/src/main/java/com/dalet/vfs2/provider/azure/AzFileObject.java
+++ b/vfs-azure/src/main/java/com/dalet/vfs2/provider/azure/AzFileObject.java
@@ -51,6 +51,7 @@ import java.net.URL;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 
@@ -348,7 +349,14 @@ public class AzFileObject extends AbstractFileObject<AzFileSystem> {
             return 0;
         }
 
-        return getBlobProperties().getLastModified().toEpochSecond();
+        return epocToMilli(getBlobProperties().getLastModified());
+    }
+
+    private long epocToMilli(OffsetDateTime offsetDateTime) {
+
+        Date date = Date.from(offsetDateTime.toInstant());
+
+        return date.getTime();
     }
 
 

--- a/vfs-azure/src/test/java/com/dalet/vfs2/provider/azure/AzFileObjectTest.java
+++ b/vfs-azure/src/test/java/com/dalet/vfs2/provider/azure/AzFileObjectTest.java
@@ -1,0 +1,70 @@
+package com.dalet.vfs2.provider.azure;
+
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.models.BlobProperties;
+import org.apache.commons.vfs2.provider.AbstractFileName;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.springframework.util.ReflectionUtils;
+
+import java.lang.reflect.Field;
+import java.time.OffsetDateTime;
+import java.util.Date;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+public class AzFileObjectTest {
+
+    private final static AbstractFileName fileName = mock(AbstractFileName.class);
+    private final static AzFileSystem fileSystem = mock(AzFileSystem.class);
+    private final static BlobClient blobClient = mock(BlobClient.class);
+    private final AzFileObject target = new AzFileObject(fileName, fileSystem);
+
+
+    @BeforeClass
+    public static void setup() {
+
+        BlobContainerClient containerClient = mock(BlobContainerClient.class);
+
+        when(fileSystem.getContainerClient()).thenReturn(containerClient);
+        when(blobClient.exists()).thenReturn(true);
+        when(fileName.getPath()).thenReturn("test/test.jpg");
+        when(containerClient.getBlobClient("test/test.jpg")).thenReturn(blobClient);
+
+        Field useCount = ReflectionUtils.findField(AzFileSystem.class, "useCount");
+        assert useCount != null;
+        useCount.setAccessible(true);
+        ReflectionUtils.setField(useCount, fileSystem, new AtomicLong());
+    }
+
+
+    private BlobProperties blobProperties(long currentTime) {
+
+        Date date = new Date(currentTime);
+
+        OffsetDateTime offsetDateTime = date.toInstant().atOffset(OffsetDateTime.now().getOffset());
+
+        return new BlobProperties(null, offsetDateTime, null, 0, null, null, null, null, null, null
+                , null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null,
+                                  null, null, null);
+    }
+
+
+    @Test
+    public void test() {
+
+        long currentTime = System.currentTimeMillis();
+
+        when(blobClient.getProperties()).thenReturn(blobProperties(currentTime));
+
+        target.doAttach();
+
+        assertEquals(currentTime, target.doGetLastModifiedTime());
+    }
+
+}

--- a/vfs-azure/src/test/java/com/dalet/vfs2/provider/azure/AzFileObjectTest.java
+++ b/vfs-azure/src/test/java/com/dalet/vfs2/provider/azure/AzFileObjectTest.java
@@ -4,9 +4,9 @@ import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.models.BlobProperties;
 import org.apache.commons.vfs2.provider.AbstractFileName;
+import org.apache.commons.vfs2.provider.AbstractFileSystem;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.springframework.util.ReflectionUtils;
 
 import java.lang.reflect.Field;
 import java.time.OffsetDateTime;
@@ -27,7 +27,7 @@ public class AzFileObjectTest {
 
 
     @BeforeClass
-    public static void setup() {
+    public static void setup() throws Exception {
 
         BlobContainerClient containerClient = mock(BlobContainerClient.class);
 
@@ -36,10 +36,9 @@ public class AzFileObjectTest {
         when(fileName.getPath()).thenReturn("test/test.jpg");
         when(containerClient.getBlobClient("test/test.jpg")).thenReturn(blobClient);
 
-        Field useCount = ReflectionUtils.findField(AzFileSystem.class, "useCount");
-        assert useCount != null;
+        Field useCount = AbstractFileSystem.class.getDeclaredField("useCount");
         useCount.setAccessible(true);
-        ReflectionUtils.setField(useCount, fileSystem, new AtomicLong());
+        useCount.set(fileSystem, new AtomicLong());
     }
 
 
@@ -56,7 +55,7 @@ public class AzFileObjectTest {
 
 
     @Test
-    public void test() {
+    public void testGetLastModifiedTime() {
 
         long currentTime = System.currentTimeMillis();
 


### PR DESCRIPTION
The last modified date was being returned in EPOC format, it was expected in milliseconds.
Added unit tests cases.
Added supports for mockito.