### PR TITLE
Support delete folder which has zero byte file

### DIFF
--- a/vfs-azure/src/main/java/com/dalet/vfs2/provider/azure/AzFileObject.java
+++ b/vfs-azure/src/main/java/com/dalet/vfs2/provider/azure/AzFileObject.java
@@ -337,8 +337,9 @@ public class AzFileObject extends AbstractFileObject<AzFileSystem> {
 
 
     /**
-     * Override delete method of VFS layer to handle folder delete scenario. In order to remove a folder we shall remove
-     * imaginary file.
+     * Override delete method of VFS layer to handle folder delete scenario. In some cases we create imaginary file (file with
+     * same name as folder and zero byte) to physical representation of folder. So while removing the folder we shall handle
+     * the case of folder delete instead of imaginary file itself.
      */
     @Override
     public boolean delete() throws FileSystemException {
@@ -370,7 +371,8 @@ public class AzFileObject extends AbstractFileObject<AzFileSystem> {
             client.delete();
         }
         catch (Exception e) {
-            //Imaginary removal is not a critical, it should not prevent removal of other children folder delete performed.
+            //Imaginary file removal is not a critical, it should not prevent removal of other files as part of folder
+            //removal operations.
 
             log.warn("Could not delete {} imaginary file", getName(), e);
         }

--- a/vfs-azure/src/main/java/com/dalet/vfs2/provider/azure/AzFileObject.java
+++ b/vfs-azure/src/main/java/com/dalet/vfs2/provider/azure/AzFileObject.java
@@ -338,8 +338,8 @@ public class AzFileObject extends AbstractFileObject<AzFileSystem> {
 
     /**
      * Override delete method of VFS layer to handle folder delete scenario. In some cases we create imaginary file (file with
-     * same name as folder and zero byte) to physical representation of folder. So while removing the folder we shall handle
-     * the case of folder delete instead of imaginary file itself.
+     * same name as folder and zero byte) for physical representation of folder. So while removing the imaginary file we shall
+     * handle the case of folder delete instead of imaginary file itself.
      */
     @Override
     public boolean delete() throws FileSystemException {

--- a/vfs-azure/src/test/java/com/dalet/vfs2/provider/azure/AzFileObjectTest.java
+++ b/vfs-azure/src/test/java/com/dalet/vfs2/provider/azure/AzFileObjectTest.java
@@ -1,9 +1,10 @@
 package com.dalet.vfs2.provider.azure;
 
+import com.azure.core.http.rest.PagedIterable;
 import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.models.BlobProperties;
-import org.apache.commons.vfs2.provider.AbstractFileName;
+import org.apache.commons.vfs2.FileType;
 import org.apache.commons.vfs2.provider.AbstractFileSystem;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -11,29 +12,28 @@ import org.junit.Test;
 import java.lang.reflect.Field;
 import java.time.OffsetDateTime;
 import java.util.Date;
+import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 
 public class AzFileObjectTest {
 
-    private final static AbstractFileName fileName = mock(AbstractFileName.class);
     private final static AzFileSystem fileSystem = mock(AzFileSystem.class);
     private final static BlobClient blobClient = mock(BlobClient.class);
-    private final AzFileObject target = new AzFileObject(fileName, fileSystem);
+    private final static BlobContainerClient containerClient = mock(BlobContainerClient.class);
 
 
     @BeforeClass
     public static void setup() throws Exception {
 
-        BlobContainerClient containerClient = mock(BlobContainerClient.class);
-
         when(fileSystem.getContainerClient()).thenReturn(containerClient);
         when(blobClient.exists()).thenReturn(true);
-        when(fileName.getPath()).thenReturn("test/test.jpg");
         when(containerClient.getBlobClient("test/test.jpg")).thenReturn(blobClient);
 
         Field useCount = AbstractFileSystem.class.getDeclaredField("useCount");
@@ -57,6 +57,10 @@ public class AzFileObjectTest {
     @Test
     public void testGetLastModifiedTime() {
 
+        AzFileName azFileName = new AzFileName("azbs", "testAccount", "testContainer", "test/test.jpg", FileType.FILE);
+
+        AzFileObject target = new AzFileObject(azFileName, fileSystem);
+
         long currentTime = System.currentTimeMillis();
 
         when(blobClient.getProperties()).thenReturn(blobProperties(currentTime));
@@ -66,4 +70,27 @@ public class AzFileObjectTest {
         assertEquals(currentTime, target.doGetLastModifiedTime());
     }
 
+
+    @Test
+    public void testDelete() throws Exception {
+
+        String parentPath = "test/video/";
+        String path = parentPath + "video";
+
+        AzFileName azFileName = new AzFileName("azbs", "testAccount", "testContainer", path, FileType.IMAGINARY);
+
+        AzFileObject target = new AzFileObject(azFileName, fileSystem);
+
+        PagedIterable pagedIterable = mock(PagedIterable.class);
+        Iterator iterator = mock(Iterator.class);
+
+        when(containerClient.listBlobsByHierarchy(path)).thenReturn(pagedIterable);
+        when(pagedIterable.iterator()).thenReturn(iterator);
+        when(iterator.hasNext()).thenReturn(false);
+        when(containerClient.getBlobClient(parentPath)).thenReturn(blobClient);
+
+        target.delete();
+        verify(containerClient, times(1)).getBlobClient(parentPath);
+        verify(blobClient, times(1)).delete();
+    }
 }


### PR DESCRIPTION
Supported added to delete a folder when it has imaginary file (zero byte file to represent physical folder for azure cloud storage)