### PR TITLE
Fixed copy issue for folders with imaginary files

### DIFF
--- a/vfs-azure/src/main/java/com/dalet/vfs2/provider/azure/AzFileObject.java
+++ b/vfs-azure/src/main/java/com/dalet/vfs2/provider/azure/AzFileObject.java
@@ -517,7 +517,7 @@ public class AzFileObject extends AbstractFileObject<AzFileSystem> {
 
                 FileType srcFileType = srcFile.getType();
 
-                if (FileType.FOLDER == srcFileType) {
+                if (!srcFileType.hasContent()) {
                     continue;
                 }
 


### PR DESCRIPTION
Handled the case when folder with nested hierarchy of folders copied and one of the children is imaginary file!